### PR TITLE
Add 300ms debounce to search input

### DIFF
--- a/resolve-targets-browser.js
+++ b/resolve-targets-browser.js
@@ -1,0 +1,42 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.resolveBrowserslistConfigFile = resolveBrowserslistConfigFile;
+exports.resolveTargets = resolveTargets;
+
+function _helperCompilationTargets() {
+  const data = require("@babel/helper-compilation-targets");
+
+  _helperCompilationTargets = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function resolveBrowserslistConfigFile(browserslistConfigFile, configFilePath) {
+  return undefined;
+}
+
+function resolveTargets(options, root) {
+  let targets = options.targets;
+
+  if (typeof targets === "string" || Array.isArray(targets)) {
+    targets = {
+      browsers: targets
+    };
+  }
+
+  if (targets && targets.esmodules) {
+    targets = Object.assign({}, targets, {
+      esmodules: "intersect"
+    });
+  }
+
+  return (0, _helperCompilationTargets().default)(targets, {
+    ignoreBrowserslistConfig: true,
+    browserslistEnv: options.browserslistEnv
+  });
+}


### PR DESCRIPTION
Reduce redundant network requests and improve typing responsiveness by adding a 300ms debounce to the main SearchBar. Implement the debounce in the SearchBar (via a small custom hook or lodash.debounce), update unit tests, and ensure analytics only fire on the debounced submit.