### PR TITLE
Debounce search input

### DIFF
--- a/grid-start.js
+++ b/grid-start.js
@@ -1,0 +1,33 @@
+let Declaration = require('../declaration')
+
+class GridStart extends Declaration {
+  /**
+   * Do not add prefix for unsupported value in IE
+   */
+  check(decl) {
+    let value = decl.value
+    return !value.includes('/') && !value.includes('span')
+  }
+
+  /**
+   * Return a final spec property
+   */
+  normalize(prop) {
+    return prop.replace('-start', '')
+  }
+
+  /**
+   * Change property name for IE
+   */
+  prefixed(prop, prefix) {
+    let result = super.prefixed(prop, prefix)
+    if (prefix === '-ms-') {
+      result = result.replace('-start', '')
+    }
+    return result
+  }
+}
+
+GridStart.names = ['grid-row-start', 'grid-column-start']
+
+module.exports = GridStart


### PR DESCRIPTION
Add a 300ms debounce to the global search input to reduce excessive API calls and avoid race conditions while users type. This updates the Search component to use lodash.debounce, cancels pending requests on unmount, and preserves previous results until new results arrive.